### PR TITLE
Add valid font for Simplified Chinese

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN chmod +x /usr/local/bin/cpdf
 
 COPY trans/static/fonts/IRANSans/ttf/* /usr/local/share/fonts/
 COPY trans/static/fonts/SourceSansPro/ttf/* /usr/local/share/fonts/
+COPY trans/static/fonts/SourceHanSerif/* /usr/local/share/fonts/
 COPY trans/static/fonts/Korean/* /usr/local/share/fonts/
 COPY trans/static/fonts/Thai/* /usr/local/share/fonts/
 COPY trans/static/fonts/Taiwan/* /usr/local/share/fonts/

--- a/trans/static/css/styles.css
+++ b/trans/static/css/styles.css
@@ -267,6 +267,10 @@ code, pre {
     font-family: CustomTextFont, 'Loma', Arial, serif;
 }
 
+.rendered_content[lang="zh-Hans"] {
+    font-family: CustomTextFont, 'Source Han Serif CN', Arial, serif;
+}
+
 .rendered_content[lang="zh"] {
     font-family: CustomTextFont, 'PMingLiU', Arial, serif;
 }


### PR DESCRIPTION
Source Han Serif CN is added for Simplified Chinese, as well as some updates on Dockerfile and styles.